### PR TITLE
0.91.1

### DIFF
--- a/encryption/builder.js
+++ b/encryption/builder.js
@@ -160,6 +160,7 @@ Builder.prototype.getUk25 = function() {
     else if (this.version.startsWith('0.85')) return Long.fromString('3081064678568720862', false, 10);
     else if (this.version.startsWith('0.87')) return Long.fromString('4500779412463383546', false, 10);
     else if (this.version.startsWith('0.89')) return Long.fromString('-782790124105039914', false, 10);
+    else if (this.version.startsWith('0.91')) return Long.fromString('-782790124105039914', false, 10);
 
     throw new Error('Unsupported encryption for version ' + this.version);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pogobuf-signature",
-  "version": "2.3.12",
+  "version": "2.3.13",
   "description": "Signature generation and hashing for [pogobuf](https://github.com/pogosandbox/pogobuf/)",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Updated the encryption builder to support the 0.91.1 API since the hashing has remained unchanged from the 0.89.1 API.